### PR TITLE
Use caret operator for dev versions when possible.

### DIFF
--- a/lib/intersect.js
+++ b/lib/intersect.js
@@ -102,7 +102,13 @@ function intersect() {
 			if (/\.0\.0$/.test(hi.semver.raw)) {
 				return '^' + lo.semver.raw;
 			} else if (/\.0$/.test(hi.semver.raw)) {
-				return '~' + lo.semver.raw;
+				// Anything in the 0.x.x line behaves like ~ even for the ^
+				// operator.
+				if (/^0\./.test(lo.semver.raw)) {
+					return '^' + lo.semver.raw;
+				} else {
+					return '~' + lo.semver.raw;
+				}
 			}
 		}
 		return lo.operator+lo.semver.raw + ' && ' + hi.operator+hi.semver.raw;


### PR DESCRIPTION
This ensures the syntax `^0.2.2` intersected with itself is still `^0.2.2`.
