### PR TITLE
Fix #3: Support infinity ranges

### DIFF
--- a/lib/intersect.js
+++ b/lib/intersect.js
@@ -93,7 +93,7 @@ function intersect() {
 		return reduce(flatten(values), combine, [ lowest, highest ]);
 	}), function(entry) {
 		var lo = entry[0], hi = entry[1];
-		return lo.test(hi.semver) && hi.test(lo.semver);
+		return hi === highest || lo === lowest || (lo.test(hi.semver) && hi.test(lo.semver));
 	});
 
 	ranges = map(ranges, function(range) {
@@ -111,7 +111,10 @@ function intersect() {
 				}
 			}
 		}
-		return lo.operator+lo.semver.raw + ' && ' + hi.operator+hi.semver.raw;
+		var result = [];
+		if (lo.semver.raw) { result.push(lo.operator+lo.semver.raw); }
+		if (hi.semver.raw) { result.push(hi.operator+hi.semver.raw); }
+		return result.join(' && ');
 	});
 
 	if (ranges.length === 0) {


### PR DESCRIPTION
Thanks for a great module! I'm just about adding support for checking the intersection of engine versions within a project and it's dependencies to my [installed-check](https://github.com/voxpelli/node-installed-check) module through the use of this module.

As noted in #3 it seems like this module currently doesn't fully support open ranges like `>=5.0.0`.

I dug into the code and found that the fix seemed to be rather simple to do and that the work was mostly done already.

So with this fix the #3 issue is gone.
